### PR TITLE
feat: add ability to reorder checklist items

### DIFF
--- a/checklist/ContentView.swift
+++ b/checklist/ContentView.swift
@@ -27,7 +27,7 @@ class ChecklistItem {
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \ChecklistItem.sortOrder) private var items: [ChecklistItem]
+    @Query(sort: \ChecklistItem.sortOrder, order: .reverse) private var items: [ChecklistItem]
     @State private var newItemText: String = ""
     @State private var editingItemId: UUID? = nil
     
@@ -125,11 +125,12 @@ struct ContentView: View {
         // Perform the move
         reorderedItems.move(fromOffsets: source, toOffset: destination)
         
-        // Update sortOrder for all items based on their new positions using timestamps
+        // Update sortOrder for all items based on their new positions
+        // Since we sort in reverse, first item needs highest value
         var timestamp = Int(Date().timeIntervalSince1970 * 1000)
         for item in reorderedItems {
             item.sortOrder = timestamp
-            timestamp += 1
+            timestamp -= 1  // Decrement so first item has highest value
         }
         
         do {

--- a/checklist/ContentView.swift
+++ b/checklist/ContentView.swift
@@ -98,17 +98,10 @@ struct ContentView: View {
     private func addItem() {
         guard !newItemText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
         
-        // Use timestamp to ensure unique sortOrder
-        let newSortOrder = Int(Date().timeIntervalSince1970 * 1000)
-        let newItem = ChecklistItem(title: newItemText, sortOrder: newSortOrder)
+        // New items get the highest sortOrder value to appear at top
+        let maxOrder = items.map { $0.sortOrder }.max() ?? -1
+        let newItem = ChecklistItem(title: newItemText, sortOrder: maxOrder + 1)
         modelContext.insert(newItem)
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Error saving item: \(error)")
-        }
-        
         newItemText = ""
     }
     
@@ -125,18 +118,11 @@ struct ContentView: View {
         // Perform the move
         reorderedItems.move(fromOffsets: source, toOffset: destination)
         
-        // Update sortOrder for all items based on their new positions
-        // Since we sort in reverse, first item needs highest value
-        var timestamp = Int(Date().timeIntervalSince1970 * 1000)
-        for item in reorderedItems {
-            item.sortOrder = timestamp
-            timestamp -= 1  // Decrement so first item has highest value
-        }
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Error saving reordered items: \(error)")
+        // Reassign sortOrder values in descending order
+        // First item gets highest value (appears at top with reverse sort)
+        let startValue = reorderedItems.count - 1
+        for (index, item) in reorderedItems.enumerated() {
+            item.sortOrder = startValue - index
         }
     }
 }

--- a/checklist/ContentView.swift
+++ b/checklist/ContentView.swift
@@ -14,18 +14,20 @@ class ChecklistItem {
     var title: String
     var isCompleted: Bool
     var createdAt: Date
+    var sortOrder: Int
     
-    init(id: UUID = UUID(), title: String, isCompleted: Bool = false, createdAt: Date = Date()) {
+    init(id: UUID = UUID(), title: String, isCompleted: Bool = false, createdAt: Date = Date(), sortOrder: Int = 0) {
         self.id = id
         self.title = title
         self.isCompleted = isCompleted
         self.createdAt = createdAt
+        self.sortOrder = sortOrder
     }
 }
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \ChecklistItem.createdAt, order: .reverse) private var items: [ChecklistItem]
+    @Query(sort: \ChecklistItem.sortOrder) private var items: [ChecklistItem]
     @State private var newItemText: String = ""
     @State private var editingItemId: UUID? = nil
     
@@ -82,6 +84,7 @@ struct ContentView: View {
                         }
                     }
                     .onDelete(perform: deleteItems)
+                    .onMove(perform: moveItems)
                 }
                 .listStyle(InsetListStyle())
             }
@@ -95,14 +98,44 @@ struct ContentView: View {
     private func addItem() {
         guard !newItemText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
         
-        let newItem = ChecklistItem(title: newItemText)
+        // Use timestamp to ensure unique sortOrder
+        let newSortOrder = Int(Date().timeIntervalSince1970 * 1000)
+        let newItem = ChecklistItem(title: newItemText, sortOrder: newSortOrder)
         modelContext.insert(newItem)
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving item: \(error)")
+        }
+        
         newItemText = ""
     }
     
     private func deleteItems(at offsets: IndexSet) {
         for index in offsets {
             modelContext.delete(items[index])
+        }
+    }
+    
+    private func moveItems(from source: IndexSet, to destination: Int) {
+        // Create a mutable copy of the items array
+        var reorderedItems = Array(items)
+        
+        // Perform the move
+        reorderedItems.move(fromOffsets: source, toOffset: destination)
+        
+        // Update sortOrder for all items based on their new positions using timestamps
+        var timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        for item in reorderedItems {
+            item.sortOrder = timestamp
+            timestamp += 1
+        }
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving reordered items: \(error)")
         }
     }
 }


### PR DESCRIPTION
## description

- added sortOrder property to ChecklistItem model
- implemented drag-and-drop reordering with .onMove modifier

## how I tested

### scenario 1
- added an item (should be on the top since new)
- added a few items (every time should be added to the top) 
- move newest item in the middle somewhere (should have been moved there)
- delete an item in the middle
- add an item (should be on top)
- add an item (should be on top)
- add an item (should be on top)
- move the newest items I added somewhere in the middle where i had deleted that item