### PR TITLE
Add auto-delete setting for completed items

### DIFF
--- a/checklist/ContentView.swift
+++ b/checklist/ContentView.swift
@@ -8,19 +8,49 @@
 import SwiftUI
 import SwiftData
 
+enum AutoDeleteOption: String, CaseIterable, Identifiable {
+    case never = "Never"
+    case threeSeconds = "3 seconds"
+    case tenSeconds = "10 seconds"
+    case oneDay = "1 day"
+    case threeDays = "3 days"
+    case oneWeek = "1 week"
+    
+    var id: String { rawValue }
+    
+    var timeInterval: TimeInterval? {
+        switch self {
+        case .never:
+            return nil
+        case .threeSeconds:
+            return 3
+        case .tenSeconds:
+            return 10
+        case .oneDay:
+            return 86400 // 24 * 60 * 60
+        case .threeDays:
+            return 259200 // 3 * 24 * 60 * 60
+        case .oneWeek:
+            return 604800 // 7 * 24 * 60 * 60
+        }
+    }
+}
+
 @Model
 class ChecklistItem {
     var id: UUID
     var title: String
     var isCompleted: Bool
     var createdAt: Date
+    var completedAt: Date?
     var sortOrder: Int
     
-    init(id: UUID = UUID(), title: String, isCompleted: Bool = false, createdAt: Date = Date(), sortOrder: Int = 0) {
+    init(id: UUID = UUID(), title: String, isCompleted: Bool = false, createdAt: Date = Date(), completedAt: Date? = nil, sortOrder: Int = 0) {
         self.id = id
         self.title = title
         self.isCompleted = isCompleted
         self.createdAt = createdAt
+        self.completedAt = completedAt
         self.sortOrder = sortOrder
     }
 }
@@ -31,6 +61,13 @@ struct ContentView: View {
     @State private var newItemText: String = ""
     @State private var editingItemId: UUID? = nil
     @State private var showingSettings = false
+    @AppStorage("autoDeleteOption") private var autoDeleteOptionRaw: String = AutoDeleteOption.never.rawValue
+    
+    private let cleanupTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    
+    private var autoDeleteOption: AutoDeleteOption {
+        AutoDeleteOption(rawValue: autoDeleteOptionRaw) ?? .never
+    }
     
     var body: some View {
         NavigationView {
@@ -58,6 +95,12 @@ struct ContentView: View {
                         HStack {
                             Button(action: {
                                 item.isCompleted.toggle()
+                                if item.isCompleted {
+                                    item.completedAt = Date()
+                                    scheduleAutoDelete(for: item)
+                                } else {
+                                    item.completedAt = nil
+                                }
                             }) {
                                 Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
                                     .foregroundColor(item.isCompleted ? .green : .gray)
@@ -105,6 +148,12 @@ struct ContentView: View {
             .sheet(isPresented: $showingSettings) {
                 SettingsView()
             }
+            .onAppear {
+                cleanupExpiredItems()
+            }
+            .onReceive(cleanupTimer) { _ in
+                cleanupExpiredItems()
+            }
         }
     }
     
@@ -138,14 +187,70 @@ struct ContentView: View {
             item.sortOrder = startValue - index
         }
     }
+    
+    private func scheduleAutoDelete(for item: ChecklistItem) {
+        guard let timeInterval = autoDeleteOption.timeInterval else { return }
+        
+        // Use Task to schedule deletion after delay
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(timeInterval * 1_000_000_000))
+            
+            // Check if item still exists and is still completed
+            if item.isCompleted, let completedAt = item.completedAt {
+                let timeSinceCompletion = Date().timeIntervalSince(completedAt)
+                if timeSinceCompletion >= timeInterval {
+                    await MainActor.run {
+                        modelContext.delete(item)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func cleanupExpiredItems() {
+        guard let timeInterval = autoDeleteOption.timeInterval else { return }
+        
+        let now = Date()
+        let itemsToDelete = items.filter { item in
+            guard item.isCompleted, let completedAt = item.completedAt else { return false }
+            return now.timeIntervalSince(completedAt) >= timeInterval
+        }
+        
+        for item in itemsToDelete {
+            modelContext.delete(item)
+        }
+    }
 }
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("autoDeleteOption") private var autoDeleteOptionRaw: String = AutoDeleteOption.never.rawValue
+    
+    private var autoDeleteOption: AutoDeleteOption {
+        get { AutoDeleteOption(rawValue: autoDeleteOptionRaw) ?? .never }
+        set { autoDeleteOptionRaw = newValue.rawValue }
+    }
     
     var body: some View {
         NavigationView {
             List {
+                Section(header: Text("Behavior")) {
+                    Picker("Auto-delete completed", selection: Binding(
+                        get: { autoDeleteOption },
+                        set: { autoDeleteOptionRaw = $0.rawValue }
+                    )) {
+                        ForEach(AutoDeleteOption.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    
+                    if autoDeleteOption != .never {
+                        Text("Completed items will be automatically deleted after \(autoDeleteOption.rawValue).")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
+                
                 Section(header: Text("About")) {
                     HStack {
                         Text("App Name")


### PR DESCRIPTION
Adds a setting to auto-delete completed checklist items after a user-defined time interval to allow users to automatically clean up their lists.

---
<a href="https://cursor.com/background-agent?bcId=bc-700a0e9b-6c2c-4187-ab30-4c957b2debb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-700a0e9b-6c2c-4187-ab30-4c957b2debb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

